### PR TITLE
Refactor recurringTransactionEvent schema and update version to 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luca-financial/luca-schema",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Schemas for the Luca Ledger application",
   "author": "Johnathan Aspinwall",
   "main": "dist/cjs/index.js",
@@ -31,8 +31,7 @@
     "build": "yarn && yarn clean && node scripts/build.mjs && babel src --out-dir dist/cjs --source-maps --ignore 'src/examples/**','src/tests/**'",
     "clean": "rimraf dist",
     "lint": "prettier --check . && eslint .",
-    "publish-beta": "yarn && yarn build && yarn publish --tag beta --access public",
-    "test": "yarn build && jest"
+    "test": "jest"
   },
   "exports": {
     ".": {

--- a/src/examples/recurringTransactionEvents.json
+++ b/src/examples/recurringTransactionEvents.json
@@ -4,7 +4,7 @@
     "transactionId": "10000000-0000-0000-0000-000000000001",
     "recurringTransactionId": "40000000-0000-0000-0000-000000000001",
     "expectedDate": "2024-02-01",
-    "status": "MODIFIED",
+    "eventState": "MODIFIED",
     "createdAt": "2024-01-01T00:00:00Z",
     "updatedAt": "2024-01-15T00:00:00Z"
   },
@@ -13,7 +13,7 @@
     "transactionId": null,
     "recurringTransactionId": "40000000-0000-0000-0000-000000000002",
     "expectedDate": "2024-02-15",
-    "status": "DELETED",
+    "eventState": "DELETED",
     "createdAt": "2024-01-10T00:00:00Z",
     "updatedAt": "2024-01-20T00:00:00Z"
   },
@@ -22,7 +22,7 @@
     "transactionId": "10000000-0000-0000-0000-000000000003",
     "recurringTransactionId": "40000000-0000-0000-0000-000000000003",
     "expectedDate": "2024-03-01",
-    "status": "MODIFIED",
+    "eventState": "MODIFIED",
     "createdAt": "2024-01-05T00:00:00Z",
     "updatedAt": "2024-01-25T00:00:00Z"
   },
@@ -31,7 +31,7 @@
     "transactionId": "10000000-0000-0000-0000-000000000004",
     "recurringTransactionId": "40000000-0000-0000-0000-000000000004",
     "expectedDate": "2024-03-15",
-    "status": "MODIFIED",
+    "eventState": "MODIFIED",
     "createdAt": "2024-01-15T00:00:00Z",
     "updatedAt": "2024-01-30T00:00:00Z"
   },
@@ -40,7 +40,7 @@
     "transactionId": null,
     "recurringTransactionId": "40000000-0000-0000-0000-000000000005",
     "expectedDate": "2024-04-01",
-    "status": "DELETED",
+    "eventState": "DELETED",
     "createdAt": "2024-01-20T00:00:00Z",
     "updatedAt": "2024-02-10T00:00:00Z"
   },
@@ -49,7 +49,7 @@
     "transactionId": "10000000-0000-0000-0000-000000000006",
     "recurringTransactionId": "40000000-0000-0000-0000-000000000006",
     "expectedDate": "2024-04-15",
-    "status": "MODIFIED",
+    "eventState": "MODIFIED",
     "createdAt": "2024-02-01T00:00:00Z",
     "updatedAt": "2024-02-15T00:00:00Z"
   },
@@ -58,7 +58,7 @@
     "transactionId": "10000000-0000-0000-0000-000000000007",
     "recurringTransactionId": "40000000-0000-0000-0000-000000000007",
     "expectedDate": "2024-05-01",
-    "status": "MODIFIED",
+    "eventState": "MODIFIED",
     "createdAt": "2024-02-05T00:00:00Z",
     "updatedAt": "2024-02-20T00:00:00Z"
   },
@@ -67,7 +67,7 @@
     "transactionId": null,
     "recurringTransactionId": "40000000-0000-0000-0000-000000000008",
     "expectedDate": "2024-05-15",
-    "status": "DELETED",
+    "eventState": "DELETED",
     "createdAt": "2024-02-10T00:00:00Z",
     "updatedAt": "2024-02-25T00:00:00Z"
   },
@@ -76,7 +76,7 @@
     "transactionId": "10000000-0000-0000-0000-000000000009",
     "recurringTransactionId": "40000000-0000-0000-0000-000000000009",
     "expectedDate": "2024-06-01",
-    "status": "MODIFIED",
+    "eventState": "MODIFIED",
     "createdAt": "2024-02-15T00:00:00Z",
     "updatedAt": "2024-03-01T00:00:00Z"
   },
@@ -85,7 +85,7 @@
     "transactionId": null,
     "recurringTransactionId": "40000000-0000-0000-0000-000000000010",
     "expectedDate": "2024-06-15",
-    "status": "DELETED",
+    "eventState": "DELETED",
     "createdAt": "2024-02-20T00:00:00Z",
     "updatedAt": "2024-03-05T00:00:00Z"
   }

--- a/src/schemas/recurringTransactionEvent.json
+++ b/src/schemas/recurringTransactionEvent.json
@@ -28,22 +28,22 @@
       "format": "date",
       "description": "The date when the occurrence is expected."
     },
-    "status": {
+    "eventState": {
       "type": "string",
-      "title": "Event Status",
+      "title": "Event State",
       "enum": ["MODIFIED", "DELETED"],
-      "description": "Status of the occurrence, indicating if it has been modified or logically deleted."
+      "description": "State of the occurrence, indicating if it has been modified or logically deleted."
     }
   },
   "required": [
     "transactionId",
     "recurringTransactionId",
     "expectedDate",
-    "status"
+    "eventState"
   ],
   "if": {
     "properties": {
-      "status": {
+      "eventState": {
         "const": "MODIFIED"
       }
     }

--- a/src/tests/test-types.test.ts
+++ b/src/tests/test-types.test.ts
@@ -129,7 +129,7 @@ test('RecurringTransactionEvent validation', () => {
     transactionId: '123e4567-e89b-12d3-a456-426614174000',
     recurringTransactionId: '123e4567-e89b-12d3-a456-426614174004',
     expectedDate: '2024-01-15',
-    status: 'MODIFIED',
+    eventState: 'MODIFIED',
     createdAt: '2024-01-01T00:00:00Z',
     updatedAt: null
   };

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -73,7 +73,7 @@ export interface RecurringTransactionEvent {
   transactionId: string | null;
   recurringTransactionId: string;
   expectedDate: string;
-  status: 'MODIFIED' | 'DELETED';
+  eventState: 'MODIFIED' | 'DELETED';
 }
 
 export interface LucaSchema {


### PR DESCRIPTION
Closes #34 
Rename 'status' to 'eventState' in the recurringTransactionEvent schema for improved clarity. Update the package version to 2.2.0 and simplify the test script in package.json.