### PR TITLE
Bump version to 1.2.3 and remove LICENSE and README.md from files list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luca-financial/luca-schema",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Schemas for the Luca Ledger application",
   "author": "Johnathan Aspinwall",
   "main": "dist/cjs/index.js",
@@ -40,9 +40,7 @@
     }
   },
   "files": [
-    "dist/",
-    "LICENSE",
-    "README.md"
+    "dist/"
   ],
   "dependencies": {
     "ajv": "^8.12.0",


### PR DESCRIPTION
This pull request updates the package version and modifies the published files in the `package.json` for `@luca-financial/luca-schema`.

Version update:

* Bumped the package version from `1.2.2` to `1.2.3` to reflect the latest changes.

Package publishing configuration:

* Updated the `files` array to only include the `dist/` directory, removing `LICENSE` and `README.md` from the list of published files.