### PR TITLE
Update changelog for version 2.1.3 and fix Ajv2020 import path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0] - 2026-01-03
+## [2.1.3] - 2026-01-18
+
+### Fixed
+
+- Use resolvable Ajv 2020 entrypoint for ESM consumers.
+
+## [2.1.2] - 2026-01-17
+
+### Changed
+
+- Refactor code structure and update package version to 2.1.2.
+
+## [2.1.1] - 2026-01-17
+
+### Changed
+
+- Switch development scripts to pnpm and update package version to 2.1.1.
+
+## [2.1.0] - 2026-01-17
 
 ### Added
 
-- Initial release of version 2.0.0 schema.
+- Add statement schema and update related files for improved transaction handling.
+
+## [2.0.0] - 2026-01-04
+
+### Changed
+
+- Refactor for Luca Ledger schema release.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luca-financial/luca-schema",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Schemas for the Luca Ledger application",
   "author": "Johnathan Aspinwall",
   "main": "dist/esm/index.js",

--- a/src/lucaValidator.js
+++ b/src/lucaValidator.js
@@ -1,4 +1,4 @@
-import Ajv2020 from 'ajv/dist/2020';
+import Ajv2020 from 'ajv/dist/2020.js';
 import addFormats from 'ajv-formats';
 import accountSchemaJson from './schemas/account.json' with { type: 'json' };
 import categorySchemaJson from './schemas/category.json' with { type: 'json' };


### PR DESCRIPTION
Update the changelog to reflect the new version 2.1.3 and ensure the correct import path for Ajv2020 for ESM consumers.