### PR TITLE
Bump version to 2.2.0 and update statement schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v2.2.0]
+
+### Changed
+
+- Replace statement `status` with boolean `isLocked` and remove `StatementStatus` enum.
 
 ## [2.1.3] - 2026-01-18
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ const statement = {
   endingBalance: number;
   totalCharges: number;
   totalPayments: number;
-  status: 'draft' | 'current' | 'past' | 'locked';
+  isLocked: boolean;
   createdAt: string;
   updatedAt: string | null;
 };

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,68 +1,32 @@
 # Luca Schema Example Data
 
-This directory contains example data files for the Luca Schema validation library.
+This directory contains example datasets used by Luca Schema for validation and documentation.
 
 ## luca-schema-example.json
 
-A comprehensive, valid example dataset that demonstrates all entity types and relationships defined in Luca Schema. This file is designed for:
+This file is a complete, valid Luca Schema document. It is intended to:
 
-- **Development & Testing**: Import realistic test data into Luca Ledger during development
-- **Documentation**: Understand the structure and relationships between different entities
-- **Validation Testing**: Verify that schema changes don't break existing data structures
-- **Integration Testing**: Test data import/export workflows
+- provide realistic sample data for development and testing,
+- demonstrate relationships across entities,
+- act as a validation fixture for schema changes,
+- serve as a reference when integrating with Luca Ledger.
 
-### Contents
+### What it includes
 
-The example file includes:
+- **Categories**: A small hierarchy with top-level and child categories.
+- **Accounts**: Checking, savings, credit card, external, and a closed account example.
+- **Statements**: Sample statements linked to the credit card account.
+- **Recurring transactions**: Multiple frequencies and states.
+- **Recurring transaction events**: Modified and deleted occurrences.
+- **Transactions**: A mix of states and categories, some linked to statements.
+- **Transaction splits**: One split transaction showing sums that match the parent.
 
-- **12 Categories**: A hierarchical category structure with parent-child relationships
-  - Top-level categories: Income, Housing, Food & Dining, Transportation, Entertainment
-  - Sub-categories for better organization (e.g., Salary under Income, Rent under Housing)
+### Data characteristics
 
-- **6 Accounts**: Various account types to demonstrate different use cases
-  - Checking account (Main Street Bank Checking)
-  - Savings account (High Yield Savings)
-  - Credit card (Rewards Credit Card)
-  - External accounts (Employer, Utilities)
-  - Closed account example (Old Savings Account)
-
-- **3 Statements**: Credit card statements in different statuses
-  - Past statement (fully reconciled)
-  - Current statement (active)
-  - Draft statement (being prepared)
-
-- **5 Recurring Transactions**: Regular transactions with different frequencies
-  - Monthly rent payment
-  - Monthly subscription (Netflix)
-  - Bi-weekly paycheck
-  - Monthly electric bill (with occurrence limit)
-  - Cancelled gym membership
-
-- **3 Recurring Transaction Events**: Modifications to recurring transaction occurrences
-  - Modified occurrence (rent with late fee)
-  - Deleted occurrence (skipped subscription payment)
-  - Modified occurrence (higher electric bill)
-
-- **20 Transactions**: Diverse transaction examples covering all states
-  - Income deposits (salary)
-  - Expense payments (rent, utilities, groceries, dining)
-  - Different transaction states: COMPLETED, PENDING, SCHEDULED, PLANNED, DISPUTED, REFUNDED, DELETED, ON_DECK
-  - Transactions with and without categories
-  - Transactions linked to statements
-  - Transactions with optional fields (memo, counterparty, currency)
-
-- **3 Transaction Splits**: Demonstration of splitting a transaction across multiple categories
-  - Single online shopping purchase split into groceries, entertainment, and utilities
-  - Note: Split amounts are always positive values representing portions of the parent transaction's absolute amount
-  - The sum of all split amounts (8000 + 5000 + 2000 = 15000) equals the absolute value of the parent transaction amount (-15000)
-
-### Data Characteristics
-
-- **Stable IDs**: Uses deterministic UUIDs for consistent references between imports
-- **Realistic Values**: Amounts are in integer minor units (cents), realistic but clearly synthetic
-- **Complete Relationships**: All foreign key relationships are valid and resolvable
-- **Edge Cases**: Includes optional fields both present and omitted, closed accounts, deleted transactions
-- **Temporal Consistency**: Dates and timestamps follow a logical chronological order
+- **Stable IDs**: Deterministic UUIDs for consistent references.
+- **Synthetic values**: Realistic but fictional amounts and dates.
+- **Complete relationships**: All foreign keys resolve.
+- **Edge cases**: Optional fields both present and omitted.
 
 ### Usage
 
@@ -70,31 +34,22 @@ The example file includes:
 import { validate } from '@luca-financial/luca-schema';
 import fs from 'fs';
 
-// Load and validate the example data
 const exampleData = JSON.parse(
   fs.readFileSync('./examples/luca-schema-example.json', 'utf8')
 );
 
 const result = validate('lucaSchema', exampleData);
-console.log('Valid:', result.valid); // true
+console.log('Valid:', result.valid);
 ```
 
 ### Validation
 
-The example file is automatically validated in the test suite to ensure it remains valid as the schema evolves. Run tests with:
+This file is validated in the test suite. Run tests with:
 
 ```bash
 pnpm test
 ```
 
-### Importing into Luca Ledger
+### Notes
 
-This file can be directly imported into Luca Ledger for development and testing. The data will populate:
-
-- A category hierarchy for organizing transactions
-- Multiple accounts across different types
-- Historical and current statements
-- Various transactions in different states
-- Examples of recurring transactions and their modifications
-
-The synthetic data is safe for development use and demonstrates common financial scenarios without containing any real personal information.
+The example data is safe for development use and contains no real personal information.

--- a/examples/luca-schema-example.json
+++ b/examples/luca-schema-example.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "2.0.0",
+  "schemaVersion": "2.2.0",
   "categories": [
     {
       "id": "de7c6d19-1109-442b-807f-02807feb8e13",
@@ -206,7 +206,7 @@
       "endingBalance": 45000,
       "totalCharges": 47500,
       "totalPayments": 2500,
-      "status": "past",
+      "isLocked": false,
       "createdAt": "2024-02-15T00:00:00Z",
       "updatedAt": null
     },
@@ -219,7 +219,7 @@
       "endingBalance": 78000,
       "totalCharges": 35000,
       "totalPayments": 2000,
-      "status": "current",
+      "isLocked": false,
       "createdAt": "2024-03-15T00:00:00Z",
       "updatedAt": null
     },
@@ -232,7 +232,7 @@
       "endingBalance": 0,
       "totalCharges": 0,
       "totalPayments": 0,
-      "status": "draft",
+      "isLocked": false,
       "createdAt": "2024-03-16T00:00:00Z",
       "updatedAt": "2024-03-20T00:00:00Z"
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luca-financial/luca-schema",
-  "version": "2.1.5",
+  "version": "2.2.0",
   "description": "Schemas for the Luca Ledger application",
   "author": "Johnathan Aspinwall",
   "main": "dist/esm/index.js",

--- a/src/examples/lucaSchema.json
+++ b/src/examples/lucaSchema.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "2.0.0",
+  "schemaVersion": "2.2.0",
   "categories": [
     {
       "id": "20000000-0000-0000-0000-000000000001",

--- a/src/schemas/enums.json
+++ b/src/schemas/enums.json
@@ -49,11 +49,6 @@
       "type": "string",
       "enum": ["MODIFIED", "DELETED"],
       "description": "Allowed statuses for recurring transaction events"
-    },
-    "StatementStatus": {
-      "type": "string",
-      "enum": ["draft", "current", "past", "locked"],
-      "description": "Allowed statuses for statements"
     }
   }
 }

--- a/src/schemas/statement.json
+++ b/src/schemas/statement.json
@@ -50,11 +50,11 @@
       "minimum": 0,
       "description": "Sum of all payments/credits during the statement period in integer minor units"
     },
-    "status": {
-      "type": "string",
-      "title": "Statement Status",
-      "$ref": "./enums.json#/$defs/StatementStatus",
-      "description": "Current status of the statement"
+    "isLocked": {
+      "type": "boolean",
+      "title": "Is Locked",
+      "default": false,
+      "description": "Whether the statement is locked for editing"
     }
   },
   "required": [
@@ -65,6 +65,6 @@
     "endingBalance",
     "totalCharges",
     "totalPayments",
-    "status"
+    "isLocked"
   ]
 }

--- a/src/tests/statement.test.js
+++ b/src/tests/statement.test.js
@@ -14,9 +14,9 @@ describe('statement schema', () => {
     expectInvalid(validate, 'statement', statement);
   });
 
-  test('missing status is invalid', () => {
+  test('missing isLocked is invalid', () => {
     const statement = makeStatement();
-    delete statement.status;
+    delete statement.isLocked;
     expectInvalid(validate, 'statement', statement);
   });
 

--- a/src/tests/test-fixtures.js
+++ b/src/tests/test-fixtures.js
@@ -95,12 +95,12 @@ const statementTemplate = {
   endingBalance: 2000,
   totalCharges: 2500,
   totalPayments: 500,
-  status: 'current'
+  isLocked: false
 };
 
 const lucaSchemaDocTemplate = {
   id: ids.lucaSchemaId,
-  schemaVersion: '1.0.0'
+  schemaVersion: '2.2.0'
 };
 
 export const makeAccount = (overrides = {}) => ({


### PR DESCRIPTION
Update the version to 2.2.0, replace the `status` field with an `isLocked` boolean in the statement schema, and enhance example data for clarity and usability.