### PR TITLE
Remove applyDefaults function and update schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luca-financial/luca-schema",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Schemas for the Luca Ledger application",
   "author": "Johnathan Aspinwall",
   "main": "dist/esm/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 import * as schemaIndex from './schemas/index.js';
 import { enums, LucaSchemas } from './enums.js';
 import {
-  applyDefaults,
   getRequiredFields,
   getValidFields,
   stripInvalidFields,
@@ -29,7 +28,6 @@ export {
   validateCollection,
   getValidFields,
   getRequiredFields,
-  stripInvalidFields,
-  applyDefaults
+  stripInvalidFields
 };
 export default schemas;

--- a/src/lucaValidator.js
+++ b/src/lucaValidator.js
@@ -89,14 +89,6 @@ function isPlainObject(value) {
   return proto === Object.prototype || proto === null;
 }
 
-function cloneDefault(value) {
-  if (typeof structuredClone === 'function') return structuredClone(value);
-  if (value && typeof value === 'object') {
-    return JSON.parse(JSON.stringify(value));
-  }
-  return value;
-}
-
 export function validate(schemaKey, data) {
   const ajv = getValidator();
   const schema = getSchema(schemaKey);
@@ -155,32 +147,6 @@ export function stripInvalidFields(schemaKey, data) {
     if (validFields.has(key)) cleaned[key] = value;
   }
   return cleaned;
-}
-
-/**
- * Returns a new object with top-level schema defaults applied for missing fields.
- * @param {string} schemaKey
- * @param {object | null | undefined} data
- * @returns {object}
- */
-export function applyDefaults(schemaKey, data) {
-  if (data === null || data === undefined) return {};
-  if (!isPlainObject(data)) {
-    throw new TypeError('Expected a plain object for data');
-  }
-  const schema = getSchema(schemaKey);
-  const properties = getSchemaProperties(schema);
-  const next = { ...data };
-  for (const [key, definition] of Object.entries(properties)) {
-    if (next[key] !== undefined) continue;
-    if (
-      definition &&
-      Object.prototype.hasOwnProperty.call(definition, 'default')
-    ) {
-      next[key] = cloneDefault(definition.default);
-    }
-  }
-  return next;
 }
 
 /**

--- a/src/schemas/account.json
+++ b/src/schemas/account.json
@@ -19,6 +19,7 @@
       "type": "string",
       "title": "Account Type",
       "$ref": "./enums.json#/$defs/AccountType",
+      "default": "SAVINGS",
       "description": "The type of the account."
     },
     "institution": {

--- a/src/schemas/category.json
+++ b/src/schemas/category.json
@@ -30,6 +30,7 @@
       "type": ["string", "null"],
       "title": "Parent Category ID",
       "format": "uuid",
+      "default": null,
       "description": "The identifier of the parent category, if any. Null if the category is top-level. Parents must be top-level (no deeper than two levels; enforced outside JSON Schema)."
     }
   },

--- a/src/schemas/recurringTransaction.json
+++ b/src/schemas/recurringTransaction.json
@@ -20,6 +20,7 @@
       "type": ["string", "null"],
       "title": "Category ID",
       "format": "uuid",
+      "default": null,
       "description": "Category identifier for organizing the transaction. Can be null if not categorized."
     },
     "amount": {
@@ -36,18 +37,21 @@
       "type": "string",
       "title": "Transaction Frequency",
       "$ref": "./enums.json#/$defs/RecurringTransactionFrequency",
+      "default": "MONTH",
       "description": "Defines the base unit of time for the repetition."
     },
     "interval": {
       "type": "integer",
       "title": "Frequency Interval",
       "minimum": 1,
+      "default": 1,
       "description": "Specifies the number of frequency units between each occurrence (e.g., every 2 weeks)."
     },
     "occurrences": {
       "type": ["integer", "null"],
       "title": "Total Occurrences",
       "minimum": 1,
+      "default": null,
       "description": "The total number of times the transaction should occur. Can be null if not specified."
     },
     "startOn": {
@@ -66,11 +70,13 @@
       "type": "string",
       "title": "Recurring Transaction State",
       "$ref": "./enums.json#/$defs/RecurringTransactionState",
+      "default": "ACTIVE",
       "description": "Current state of the recurring transaction series."
     }
   },
   "required": [
     "accountId",
+    "categoryId",
     "amount",
     "description",
     "frequency",

--- a/src/schemas/transaction.json
+++ b/src/schemas/transaction.json
@@ -52,20 +52,11 @@
       "minLength": 1,
       "description": "Description of the transaction"
     },
-    "memo": {
-      "type": ["string", "null"],
-      "title": "Memo",
-      "description": "Additional notes for the transaction."
-    },
-    "counterparty": {
-      "type": ["string", "null"],
-      "title": "Counterparty",
-      "description": "Name of the other party (merchant/payor/payee)."
-    },
     "categoryId": {
       "type": ["string", "null"],
       "title": "Category ID",
       "format": "uuid",
+      "default": null,
       "description": "Category UUID for this transaction"
     },
     "statementId": {
@@ -83,6 +74,7 @@
       "type": "string",
       "title": "Transaction State",
       "$ref": "./enums.json#/$defs/TransactionState",
+      "default": "PLANNED",
       "description": "The current state of the transaction."
     }
   },

--- a/src/schemas/transactionSplit.json
+++ b/src/schemas/transactionSplit.json
@@ -26,17 +26,13 @@
       "type": ["string", "null"],
       "title": "Category ID",
       "format": "uuid",
+      "default": null,
       "description": "The identifier of the category for this split."
     },
     "description": {
       "type": ["string", "null"],
       "title": "Description",
       "description": "Optional description for the split."
-    },
-    "memo": {
-      "type": ["string", "null"],
-      "title": "Memo",
-      "description": "Additional notes for this split."
     }
   },
   "required": ["transactionId", "amount", "categoryId"]


### PR DESCRIPTION
Eliminate the `applyDefaults` function and its related logic to streamline validation. Update the version to 2.3.1 and add default values to various schemas for improved data handling.