### PR TITLE
Bump version to 2.3.3 and update release workflow to use npm trusted publisher (OIDC)

### DIFF
--- a/.github/workflows/tag-release-publish.yml
+++ b/.github/workflows/tag-release-publish.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -63,6 +66,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to npm
-        run: pnpm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: pnpm publish --access public --provenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.3] - 2026-02-06
+
+### Changed
+
+- Update release workflow to use npm trusted publisher (OIDC) instead of an access token.
+
 ## [2.3.2] - 2026-02-06
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luca-financial/luca-schema",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Schemas for the Luca Ledger application",
   "author": "Johnathan Aspinwall",
   "main": "dist/esm/index.js",


### PR DESCRIPTION
# Summary  
Update the version and enhance the release workflow for improved security.  

## Changes  
- Bump version from 2.3.2 to 2.3.3.  
- Modify the release workflow to utilize npm trusted publisher (OIDC) instead of an access token.  

## Checklist  
- [x] Increment Version in package.json (semantic versioning)  
- [x] Updated README or documentation if needed  
- [x] Updated changelog if needed  
- [x] Updated/added tests if needed  
- [x] Updated/added examples if needed  
- [x] Ran pnpm test, all tests pass  
- [x] Ran pnpm lint  

## Related Issues  
-

