### PR TITLE
Fix GitHub Actions workflow for tagging and publishing

### DIFF
--- a/.github/workflows/tag-release-publish.yml
+++ b/.github/workflows/tag-release-publish.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Use Node.js
         uses: actions/setup-node@v4
@@ -40,6 +42,7 @@ jobs:
 
       - name: Check if tag already exists
         run: |
+          git fetch --tags
           if git rev-parse ${{ steps.get_version.outputs.version }} >/dev/null 2>&1; then
             echo "::error::Tag ${{ steps.get_version.outputs.version }} already exists. Did you forget to bump the version in package.json?"
             exit 1
@@ -51,8 +54,6 @@ jobs:
           git config user.email "github-actions@github.com"
           git tag ${{ steps.get_version.outputs.version }}
           git push origin ${{ steps.get_version.outputs.version }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create GitHub Release
         uses: ncipollo/release-action@v1
@@ -62,9 +63,16 @@ jobs:
           body: Automated release for version ${{ steps.get_version.outputs.version }}.
           draft: false
           prerelease: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine npm dist-tag
+        id: npm_tag
+        run: |
+          version=$(node -p "require('./package.json').version")
+          tag=latest
+          if [[ "$version" == *-* ]]; then
+            tag=$(echo "$version" | cut -d- -f2 | cut -d. -f1)
+          fi
+          echo "tag=$tag" >> $GITHUB_OUTPUT
 
       - name: Publish to npm
-        run: pnpm publish --access public --provenance
-        run: pnpm publish --access public --provenance
+        run: pnpm publish --access public --provenance --tag ${{ steps.npm_tag.outputs.tag }}

--- a/.github/workflows/tag-release-publish.yml
+++ b/.github/workflows/tag-release-publish.yml
@@ -19,8 +19,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-        with:
-          fetch-depth: 0
 
       - name: Use Node.js
         uses: actions/setup-node@v4
@@ -47,7 +45,6 @@ jobs:
 
       - name: Check if tag already exists
         run: |
-          git fetch --tags
           git fetch --tags
           if git rev-parse ${{ steps.get_version.outputs.version }} >/dev/null 2>&1; then
             echo "::error::Tag ${{ steps.get_version.outputs.version }} already exists. Did you forget to bump the version in package.json?"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luca-financial/luca-schema",
-  "version": "2.3.4-beta.1",
+  "version": "2.3.4-beta.2",
   "description": "Schemas for the Luca Ledger application",
   "author": "Johnathan Aspinwall",
   "main": "dist/esm/index.js",


### PR DESCRIPTION
# Summary

This pull request addresses issues with the GitHub Actions workflow for tagging and publishing by ensuring tags are fetched correctly and setting the npm dist-tag appropriately.

## Changes

- Fixed the GitHub Actions workflow to fetch tags before checking for existing tags.
- Added logic to determine the npm dist-tag based on the version in package.json.
- Bumped the version in package.json to 2.3.4-beta.2.

## Checklist

- [x] Increment Version in package.json (semantic versioning)
- [x] Updated README or documentation if needed
- [x] Updated changelog if needed
- [x] Updated/added tests if needed
- [x] Updated/added examples if needed
- [x] Ran pnpm test, all tests pass
- [x] Ran pnpm lint

## Related Issues

-

