### PR TITLE
Export SCHEMA_VERSION and enhance documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.2] - 2026-02-14
+
+### Changed
+
+- Export `SCHEMA_VERSION` for consumers to read the contract version without schema-shape coupling.
+- Add tests to verify `SCHEMA_VERSION` matches `lucaSchema.properties.schemaVersion.const` and example schemaVersion values.
+- Update README validator utilities docs to include `SCHEMA_VERSION`.
+
 ## [3.0.1] - 2026-02-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ This module exports helper utilities to inspect schemas and validate data:
 
 ```typescript
 import {
+  SCHEMA_VERSION,
   validate,
   validateCollection,
   getDateFieldPaths,
@@ -244,6 +245,7 @@ import {
 } from '@luca-financial/luca-schema';
 ```
 
+- `SCHEMA_VERSION` → schema contract version from `lucaSchema.properties.schemaVersion.const`
 - `validate(schemaKey, data)` → `{ valid: boolean, errors: AjvError[] }`
 - `validateCollection(schemaKey, array)` → `{ valid: boolean, errors: [{ index, entity, errors }] }`
 - `getDateFieldPaths(schemaKey)` → `string[]` of `format: date` fields for a schema key

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luca-financial/luca-schema",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Schemas for the Luca Ledger application",
   "author": "Johnathan Aspinwall",
   "main": "dist/esm/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,7 @@ const schemas = {
 export const accountSchema = schemas.account;
 export const categorySchema = schemas.category;
 export const lucaSchema = schemas.lucaSchema;
+export const SCHEMA_VERSION = lucaSchemaJson.properties.schemaVersion.const;
 export const statementSchema = schemas.statement;
 export const recurringTransactionSchema = schemas.recurringTransaction;
 export const recurringTransactionEventSchema =

--- a/src/tests/exampleFile.test.js
+++ b/src/tests/exampleFile.test.js
@@ -1,5 +1,5 @@
 import { describe, test, expect } from '@jest/globals';
-import { validate } from '../index.js';
+import { validate, SCHEMA_VERSION } from '../index.js';
 import exampleData from '../../examples/luca-schema-example.json' with { type: 'json' };
 
 describe('luca-schema-example.json', () => {
@@ -8,6 +8,10 @@ describe('luca-schema-example.json', () => {
 
     expect(result.valid).toBe(true);
     expect(result.errors).toEqual([]);
+  });
+
+  test('example file schemaVersion matches exported SCHEMA_VERSION', () => {
+    expect(exampleData.schemaVersion).toBe(SCHEMA_VERSION);
   });
 
   test('example file contains all entity types', () => {

--- a/src/tests/lucaSchema.test.js
+++ b/src/tests/lucaSchema.test.js
@@ -1,5 +1,5 @@
-import { describe, test } from '@jest/globals';
-import { validate } from '../index.js';
+import { describe, expect, test } from '@jest/globals';
+import { validate, SCHEMA_VERSION, lucaSchema } from '../index.js';
 import {
   makeLucaSchemaDoc,
   makeAccount,
@@ -13,6 +13,10 @@ import {
 } from './test-fixtures.js';
 
 describe('lucaSchema aggregate', () => {
+  test('exports SCHEMA_VERSION from lucaSchema contract', () => {
+    expect(SCHEMA_VERSION).toBe(lucaSchema.properties.schemaVersion.const);
+  });
+
   test('valid lucaSchema document', () => {
     const lucaSchemaDoc = makeLucaSchemaDoc();
     expectValid(validate, 'lucaSchema', lucaSchemaDoc);


### PR DESCRIPTION
# Summary

This pull request introduces the export of `SCHEMA_VERSION` to allow consumers to access the schema contract version without coupling to the schema shape.

## Changes

- Exported `SCHEMA_VERSION` from the schema for easier access.
- Updated documentation to include information about `SCHEMA_VERSION`.
- Added tests to ensure `SCHEMA_VERSION` aligns with the expected schema version values.

## Checklist

- [x] Increment Version in package.json (semantic versioning)
- [x] Updated README or documentation if needed
- [x] Updated changelog if needed
- [x] Updated/added tests if needed
- [x] Updated/added examples if needed
- [x] Ran pnpm test, all tests pass
- [x] Ran pnpm lint

## Related Issues

-

