### PR TITLE
Add Cash and Escrow Account Types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2026-04-04
+
+### Added
+
+- Support `CASH` and `ESCROW` as valid `AccountType` enum values.
+- Add `CASH` and `ESCROW` account examples to bundled example datasets.
+- Add validation tests covering `CASH` and `ESCROW` account types.
+
+### Changed
+
+- Update README account schema documentation to include the new account types.
+
+## [3.0.3] - 2026-03-18
+
+### Changed
+
+- Upgrade runtime and development dependencies to their latest compatible versions.
+- Refresh the linting and test toolchain, including the ESLint and Jest stacks.
+- Regenerate `pnpm-lock.yaml` to capture the updated dependency graph for the 3.0.3 release.
+
 ## [3.0.2] - 2026-02-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Validates financial accounts.
 const account = {
   id: string;
   name: string;
-  type: 'CHECKING' | 'SAVINGS' | 'CREDIT_CARD' | 'EXTERNAL';
+  type: 'CHECKING' | 'SAVINGS' | 'CASH' | 'CREDIT_CARD' | 'ESCROW' | 'EXTERNAL';
   institution: string | null;
   aggregationServiceId: string | null;
   statementClosingDay: number | null;

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ const common = {
 
 Validates financial accounts.
 
+Supported account types include `CHECKING`, `SAVINGS`, `CASH`, `CREDIT_CARD`, `ESCROW`, and `EXTERNAL`. Use `CASH` for physical cash balances and `ESCROW` for held-funds accounts such as deposits or tax escrows.
+
 ```typescript
 const account = {
   id: string;

--- a/examples/luca-schema-example.json
+++ b/examples/luca-schema-example.json
@@ -168,6 +168,34 @@
       "updatedAt": null
     },
     {
+      "id": "50c75f50-3246-45d0-ac5c-cd317c1797d2",
+      "name": "Property Tax Escrow",
+      "type": "ESCROW",
+      "institution": "Main Street Bank",
+      "aggregationServiceId": null,
+      "statementClosingDay": null,
+      "paymentDueDate": null,
+      "creditLimit": null,
+      "apr": null,
+      "closedAt": null,
+      "createdAt": "2024-01-02T00:00:00Z",
+      "updatedAt": null
+    },
+    {
+      "id": "3dff9295-67cf-4827-b8ab-d28835cb6f55",
+      "name": "Cash Wallet",
+      "type": "CASH",
+      "institution": null,
+      "aggregationServiceId": null,
+      "statementClosingDay": null,
+      "paymentDueDate": null,
+      "creditLimit": null,
+      "apr": null,
+      "closedAt": null,
+      "createdAt": "2024-01-03T00:00:00Z",
+      "updatedAt": null
+    },
+    {
       "id": "b4067fbe-3a9e-4c8d-82bd-af651d03cad1",
       "name": "City Utilities Department",
       "type": "EXTERNAL",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luca-financial/luca-schema",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "description": "Schemas for the Luca Ledger application",
   "author": "Johnathan Aspinwall",
   "main": "dist/esm/index.js",

--- a/src/examples/accounts.json
+++ b/src/examples/accounts.json
@@ -78,5 +78,21 @@
     "statementClosingDay": null,
     "createdAt": "2024-01-14T00:00:00Z",
     "updatedAt": null
+  },
+  {
+    "id": "00000000-0000-0000-0000-000000000011",
+    "name": "Security Deposit Escrow",
+    "type": "ESCROW",
+    "statementClosingDay": null,
+    "createdAt": "2024-01-15T00:00:00Z",
+    "updatedAt": null
+  },
+  {
+    "id": "00000000-0000-0000-0000-000000000012",
+    "name": "Cash Wallet",
+    "type": "CASH",
+    "statementClosingDay": null,
+    "createdAt": "2024-01-16T00:00:00Z",
+    "updatedAt": null
   }
 ]

--- a/src/examples/lucaSchema.json
+++ b/src/examples/lucaSchema.json
@@ -42,6 +42,22 @@
       "statementClosingDay": null,
       "createdAt": "2024-01-03T00:00:00Z",
       "updatedAt": null
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000004",
+      "name": "Lease Deposit Escrow",
+      "type": "ESCROW",
+      "statementClosingDay": null,
+      "createdAt": "2024-01-04T00:00:00Z",
+      "updatedAt": null
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000005",
+      "name": "Petty Cash",
+      "type": "CASH",
+      "statementClosingDay": null,
+      "createdAt": "2024-01-05T00:00:00Z",
+      "updatedAt": null
     }
   ],
   "recurringTransactions": [],

--- a/src/schemas/enums.json
+++ b/src/schemas/enums.json
@@ -16,7 +16,14 @@
   "$defs": {
     "AccountType": {
       "type": "string",
-      "enum": ["CHECKING", "SAVINGS", "CREDIT_CARD", "EXTERNAL"],
+      "enum": [
+        "CHECKING",
+        "SAVINGS",
+        "CASH",
+        "CREDIT_CARD",
+        "ESCROW",
+        "EXTERNAL"
+      ],
       "description": "Allowed account types"
     },
     "TransactionState": {

--- a/src/tests/account.test.js
+++ b/src/tests/account.test.js
@@ -8,6 +8,16 @@ describe('account schema', () => {
     expectValid(validate, 'account', account);
   });
 
+  test('cash account type is valid', () => {
+    const account = makeAccount({ type: 'CASH' });
+    expectValid(validate, 'account', account);
+  });
+
+  test('escrow account type is valid', () => {
+    const account = makeAccount({ type: 'ESCROW' });
+    expectValid(validate, 'account', account);
+  });
+
   test('missing type is invalid', () => {
     const account = makeAccount();
     delete account.type;


### PR DESCRIPTION
# Summary

This pull request expands the supported financial account types by introducing `CASH` and `ESCROW` as valid account types throughout the schema, documentation, and example data. It also adds corresponding test cases to ensure these new types are properly validated.

**Schema and Validation Updates:**

* Added `CASH` and `ESCROW` to the allowed values for the `AccountType` enum in `src/schemas/enums.json`, ensuring these types are recognized as valid account types.
* Updated the account type definition in the documentation (`README.md`) to include `CASH` and `ESCROW`.

**Example Data Updates:**

* Added example accounts of type `CASH` and `ESCROW` to `src/examples/accounts.json` and `src/examples/lucaSchema.json`. [[1]](diffhunk://#diff-c4d1d3426d76d9d4dbfb513a1c20b34698beb37732a13ee6cb7a0543561ee2d9R81-R96) [[2]](diffhunk://#diff-90b35d3633cd19c3d6a77f3d3f6ce92d4107b26e71a6f0eee478e7426645f475R45-R60)
* Updated `examples/luca-schema-example.json` with new sample accounts for `CASH` and `ESCROW`.

**Testing:**

* Added tests to validate that accounts with type `CASH` and `ESCROW` are accepted by the schema in `src/tests/account.test.js`.

**Versioning:**

* Bumped the package version to `3.1.0` to reflect the addition of new account types.

## Changes

- Introduced new account types: CASH and ESCROW in the schema.
- Updated examples and tests to include the new account types.
- Bumped version to 3.1.0 in package.json.

## Checklist

- [x] Increment Version in package.json (semantic versioning)
- [x] Updated README or documentation if needed
- [x] Updated changelog if needed
- [x] Updated/added tests if needed
- [x] Updated/added examples if needed
- [x] Ran pnpm test, all tests pass
- [x] Ran pnpm lint
