### PR TITLE
Fix/linked transactions same vs opposite sign amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.1] - 2026-04-05
+
+### Changed
+
+- Require `isSameSign` on both `transactionLink` and `recurringTransactionLink` so linked amounts can explicitly indicate same-sign versus opposite-sign matching behavior.
+- Update bundled examples, fixtures, tests, and README documentation to reflect the new required link-sign behavior flag.
+
 ## [3.3.0] - 2026-04-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ const recurringTransactionLink = {
   id: string;
   sourceRecurringTransactionId: string;
   destinationRecurringTransactionId: string;
+  isSameSign: boolean;
   createdAt: string;
   updatedAt: string | null;
   deletedAt?: string | null;
@@ -235,6 +236,7 @@ const transactionLink = {
   id: string;
   sourceTransactionId: string;
   destinationTransactionId: string;
+  isSameSign: boolean;
   createdAt: string;
   updatedAt: string | null;
   deletedAt?: string | null;
@@ -242,7 +244,7 @@ const transactionLink = {
 };
 ```
 
-Cross-transaction rules like matching dates, matching amounts, or opposite signs are not enforced by this schema and should be handled in application logic.
+`isSameSign` indicates whether linked amounts should share the same sign (`true`) or use opposite signs (`false`) while still matching by absolute value. Cross-transaction rules like matching dates or verifying absolute-value equality are not enforced by this schema and should be handled in application logic.
 
 ### LucaSchema
 

--- a/examples/luca-schema-example.json
+++ b/examples/luca-schema-example.json
@@ -406,6 +406,7 @@
       "id": "54b10a24-6511-48c2-bf3c-1cc7a794e2ab",
       "sourceRecurringTransactionId": "be4ac69f-89d0-444d-bf22-d4d8ec1b34a8",
       "destinationRecurringTransactionId": "37017f0d-8b46-47eb-929a-28e98ba9f84a",
+      "isSameSign": false,
       "createdAt": "2024-01-01T00:05:00Z",
       "updatedAt": null
     }
@@ -795,6 +796,7 @@
       "id": "d6ae6cc3-5949-4bb2-8187-d1be36df94a1",
       "sourceTransactionId": "75b5faeb-acde-4c4c-8401-0bf2c4f1e9d1",
       "destinationTransactionId": "08bfed71-ab12-4898-ac9c-f2980eefa945",
+      "isSameSign": false,
       "createdAt": "2024-02-01T00:05:00Z",
       "updatedAt": null
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luca-financial/luca-schema",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Schemas for the Luca Ledger application",
   "author": "Johnathan Aspinwall",
   "main": "dist/esm/index.js",

--- a/src/examples/lucaSchema.json
+++ b/src/examples/lucaSchema.json
@@ -99,6 +99,7 @@
       "id": "42000000-0000-0000-0000-000000000001",
       "sourceRecurringTransactionId": "40000000-0000-0000-0000-000000000011",
       "destinationRecurringTransactionId": "40000000-0000-0000-0000-000000000012",
+      "isSameSign": false,
       "createdAt": "2024-01-10T00:05:00Z",
       "updatedAt": null
     }
@@ -170,6 +171,7 @@
       "id": "12000000-0000-0000-0000-000000000001",
       "sourceTransactionId": "10000000-0000-0000-0000-000000000004",
       "destinationTransactionId": "10000000-0000-0000-0000-000000000005",
+      "isSameSign": false,
       "createdAt": "2024-01-12T09:05:00Z",
       "updatedAt": null
     }

--- a/src/examples/recurringTransactionLinks.json
+++ b/src/examples/recurringTransactionLinks.json
@@ -3,6 +3,7 @@
     "id": "42000000-0000-0000-0000-000000000001",
     "sourceRecurringTransactionId": "40000000-0000-0000-0000-000000000011",
     "destinationRecurringTransactionId": "40000000-0000-0000-0000-000000000012",
+    "isSameSign": false,
     "createdAt": "2024-03-01T09:00:00Z",
     "updatedAt": null
   }

--- a/src/examples/transactionLinks.json
+++ b/src/examples/transactionLinks.json
@@ -3,6 +3,7 @@
     "id": "12000000-0000-0000-0000-000000000001",
     "sourceTransactionId": "10000000-0000-0000-0000-000000000011",
     "destinationTransactionId": "10000000-0000-0000-0000-000000000012",
+    "isSameSign": false,
     "createdAt": "2024-03-05T10:05:00Z",
     "updatedAt": null
   }

--- a/src/schemas/recurringTransactionLink.json
+++ b/src/schemas/recurringTransactionLink.json
@@ -21,11 +21,17 @@
       "title": "Destination Recurring Transaction ID",
       "format": "uuid",
       "description": "UUID of the destination recurring transaction in the link."
+    },
+    "isSameSign": {
+      "type": "boolean",
+      "title": "Is Same Sign",
+      "description": "Whether the linked recurring transactions are expected to have matching signs. When false, the linked recurring transactions are expected to have opposite signs."
     }
   },
   "unevaluatedProperties": false,
   "required": [
     "sourceRecurringTransactionId",
-    "destinationRecurringTransactionId"
+    "destinationRecurringTransactionId",
+    "isSameSign"
   ]
 }

--- a/src/schemas/transactionLink.json
+++ b/src/schemas/transactionLink.json
@@ -21,8 +21,13 @@
       "title": "Destination Transaction ID",
       "format": "uuid",
       "description": "UUID of the destination transaction in the link."
+    },
+    "isSameSign": {
+      "type": "boolean",
+      "title": "Is Same Sign",
+      "description": "Whether the linked transactions are expected to have matching signs. When false, the linked transactions are expected to have opposite signs."
     }
   },
   "unevaluatedProperties": false,
-  "required": ["sourceTransactionId", "destinationTransactionId"]
+  "required": ["sourceTransactionId", "destinationTransactionId", "isSameSign"]
 }

--- a/src/tests/recurringTransactionLink.test.js
+++ b/src/tests/recurringTransactionLink.test.js
@@ -22,6 +22,27 @@ describe('recurringTransactionLink schema', () => {
     );
   });
 
+  test('missing isSameSign is invalid', () => {
+    const recurringTransactionLink = makeRecurringTransactionLink();
+    delete recurringTransactionLink.isSameSign;
+    expectInvalid(
+      validate,
+      'recurringTransactionLink',
+      recurringTransactionLink
+    );
+  });
+
+  test('non-boolean isSameSign is invalid', () => {
+    const recurringTransactionLink = makeRecurringTransactionLink({
+      isSameSign: 'false'
+    });
+    expectInvalid(
+      validate,
+      'recurringTransactionLink',
+      recurringTransactionLink
+    );
+  });
+
   test('unknown fields are invalid', () => {
     const recurringTransactionLink = makeRecurringTransactionLink({
       unexpectedField: 'x'

--- a/src/tests/test-fixtures.js
+++ b/src/tests/test-fixtures.js
@@ -66,7 +66,8 @@ const recurringTransactionLinkTemplate = {
   id: ids.recurringTransactionLinkId,
   ...commonBase,
   sourceRecurringTransactionId: ids.recurringTransactionId,
-  destinationRecurringTransactionId: ids.linkedRecurringTransactionId
+  destinationRecurringTransactionId: ids.linkedRecurringTransactionId,
+  isSameSign: false
 };
 
 const transactionTemplate = {
@@ -101,7 +102,8 @@ const transactionLinkTemplate = {
   id: ids.transactionLinkId,
   ...commonBase,
   sourceTransactionId: ids.transactionId,
-  destinationTransactionId: ids.linkedTransactionId
+  destinationTransactionId: ids.linkedTransactionId,
+  isSameSign: false
 };
 
 const statementTemplate = {

--- a/src/tests/transactionLink.test.js
+++ b/src/tests/transactionLink.test.js
@@ -18,6 +18,17 @@ describe('transactionLink schema', () => {
     expectInvalid(validate, 'transactionLink', transactionLink);
   });
 
+  test('missing isSameSign is invalid', () => {
+    const transactionLink = makeTransactionLink();
+    delete transactionLink.isSameSign;
+    expectInvalid(validate, 'transactionLink', transactionLink);
+  });
+
+  test('non-boolean isSameSign is invalid', () => {
+    const transactionLink = makeTransactionLink({ isSameSign: 'false' });
+    expectInvalid(validate, 'transactionLink', transactionLink);
+  });
+
   test('unknown fields are invalid', () => {
     const transactionLink = makeTransactionLink({ unexpectedField: 'x' });
     expectInvalid(validate, 'transactionLink', transactionLink);


### PR DESCRIPTION
# Summary

This pull request introduces a required isSameSign property to both transactionLink and recurringTransactionLink schemas. This property explicitly indicates whether linked transactions should have matching or opposite signs, improving clarity and validation of link semantics. The update also propagates this requirement through all bundled examples, fixtures, tests, and documentation to ensure consistency and correctness.

**Schema and Validation Updates:**

* Added required boolean property isSameSign to both `transactionLink` (`src/schemas/transactionLink.json`) and `recurringTransactionLink` (`src/schemas/recurringTransactionLink.json`) schemas to specify sign-matching behavior for linked transactions. The property is now mandatory. [[1]](diffhunk://#diff-7fc425cf6e671c5c798492b4ed2e3fc7acbced17274bc15a2875d771b22189b8R24-R32) [[2]](diffhunk://#diff-b36432c4e18ce6451e56c42fad0b9c58fcf6d444689449c9958b4925b62699d4R24-R35)
* Updated validation tests to ensure that missing or non-boolean isSameSign values are invalid for both link types. [[1]](diffhunk://#diff-dc09573809e60276e2b8ff2129a529279e5937cc7af29cc260f2984628ec7946R21-R31) [[2]](diffhunk://#diff-cdca3b40ffdc4bdd8bc047397b029012eb52e0ba99d6ec5283e806796fa6b21eR25-R45)

**Documentation and Example Updates:**

* Updated `README.md` to document the new isSameSign property for both link types and clarified its meaning in the schema description. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R222) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R239-R247)
* Revised all example JSON files (`examples/luca-schema-example.json`, `src/examples/lucaSchema.json`, `src/examples/recurringTransactionLinks.json`, `src/examples/transactionLinks.json`) to include the isSameSign property in all transaction link objects. [[1]](diffhunk://#diff-b5280d9aae93a589f7aa2b0558700cc1d12bc2454c7b7556ae4497a91281d828R409) [[2]](diffhunk://#diff-b5280d9aae93a589f7aa2b0558700cc1d12bc2454c7b7556ae4497a91281d828R799) [[3]](diffhunk://#diff-90b35d3633cd19c3d6a77f3d3f6ce92d4107b26e71a6f0eee478e7426645f475R102) [[4]](diffhunk://#diff-90b35d3633cd19c3d6a77f3d3f6ce92d4107b26e71a6f0eee478e7426645f475R174) [[5]](diffhunk://#diff-b383e4946ed52f74cc8d3ae93aaee7de4be6c26acae5eb3bc5ae88064c4b1074R6) [[6]](diffhunk://#diff-288f92713bbc2b31e896226aa49bfac6e5f683f195ef2b7470ad372d5bc98767R6)

**Test Fixtures and Metadata:**

* Updated test fixtures to include isSameSign in all relevant link templates. [[1]](diffhunk://#diff-89a6fa048b5282ab3ee67646f797c8a0a98fae8280c15f80d62ac896c4800c66L69-R70) [[2]](diffhunk://#diff-89a6fa048b5282ab3ee67646f797c8a0a98fae8280c15f80d62ac896c4800c66L104-R106)
* Bumped package version to 3.3.1 and added a changelog entry describing the new requirement and related updates. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R14)

## Changes

- Added `isSameSign` boolean flag to transaction and recurring transaction links to indicate whether linked amounts should share the same sign or use opposite signs.
- Updated schemas, examples, and tests to incorporate the new flag and ensure proper validation.

## Checklist

- [x] Increment Version in package.json (semantic versioning)
- [x] Updated README or documentation if needed
- [x] Updated changelog if needed
- [x] Updated/added tests if needed
- [x] Updated/added examples if needed
- [x] Ran pnpm test, all tests pass
- [x] Ran pnpm lint
