### PR TITLE
Bump schema version to 3.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.2] - 2026-04-05
+
+### Changed
+
+- Bump the Luca Schema contract version to `3.3.2`.
+- Align bundled aggregate example files with `SCHEMA_VERSION` so example validation and version-consistency checks stay in sync.
+
 ## [3.3.1] - 2026-04-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Validates the full ledger export.
 
 ```typescript
 const lucaSchema = {
-  schemaVersion: '3.0.0';
+  schemaVersion: '3.3.2';
   categories: Category[];
   accounts: Account[];
   statements: Statement[];

--- a/examples/luca-schema-example.json
+++ b/examples/luca-schema-example.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "3.0.0",
+  "schemaVersion": "3.3.2",
   "categories": [
     {
       "id": "de7c6d19-1109-442b-807f-02807feb8e13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luca-financial/luca-schema",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Schemas for the Luca Ledger application",
   "author": "Johnathan Aspinwall",
   "main": "dist/esm/index.js",

--- a/src/examples/lucaSchema.json
+++ b/src/examples/lucaSchema.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "3.0.0",
+  "schemaVersion": "3.3.2",
   "categories": [
     {
       "id": "20000000-0000-0000-0000-000000000001",

--- a/src/schemas/lucaSchema.json
+++ b/src/schemas/lucaSchema.json
@@ -17,7 +17,7 @@
   "properties": {
     "schemaVersion": {
       "type": "string",
-      "const": "3.0.0",
+      "const": "3.3.2",
       "description": "Schema contract version of the luca ledger"
     },
     "categories": {


### PR DESCRIPTION
# Summary

This pull request updates the Luca Schema contract version to `3.3.2` and ensures that all bundled example files and schema definitions are aligned with this new version. This helps maintain consistency between the schema version and the example files, supporting accurate validation and version checks.

Version update and schema alignment:

* Bumped the package version in `package.json` to `3.3.2` to reflect the new schema contract version.
* Updated the `schemaVersion` property in `src/schemas/lucaSchema.json` to require `"3.3.2"` for validation.
* Changed the `schemaVersion` field in both `examples/luca-schema-example.json` and `src/examples/lucaSchema.json` to `"3.3.2"` to match the new contract version. [[1]](diffhunk://#diff-b5280d9aae93a589f7aa2b0558700cc1d12bc2454c7b7556ae4497a91281d828L2-R2) [[2]](diffhunk://#diff-90b35d3633cd19c3d6a77f3d3f6ce92d4107b26e71a6f0eee478e7426645f475L2-R2)
* Added a changelog entry documenting the version bump and the alignment of example files with the schema version.

## Changes

- Incremented the version in `package.json` to 3.3.2.
- Updated the schema version in `lucaSchema.json` to 3.3.2.

## Checklist

- [x] Increment Version in package.json (semantic versioning)
- [x] Updated README or documentation if needed
- [x] Updated changelog if needed
- [x] Updated/added tests if needed
- [x] Updated/added examples if needed
- [x] Ran pnpm test, all tests pass
- [x] Ran pnpm lint
